### PR TITLE
Cross compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Backup files from conversion with six and future
+*.bak
+
+# VSCode Configuration
+.vscode

--- a/api/client.py
+++ b/api/client.py
@@ -97,6 +97,7 @@ def call(call, method="GET", **kwargs):
 	elif method == "GET":
 		out = six.moves.urllib.request.urlopen(req, timeout = TIMEOUT).read()
 	else:
+		# Encoding specified manually for urlargs with six. Not specifying breaks cross-compatibility.
 		out = six.moves.urllib.request.urlopen(req, six.b(urlargs), timeout = TIMEOUT).read()
 
 	try:
@@ -108,7 +109,6 @@ def call(call, method="GET", **kwargs):
 		print("Error: %s"%out['error'])
 
 	if PRESS_KEY_AFTER_CALL:
-		#eval(input("API Call Complete (press enter to continue)"))
 		input("API Call Complete (press enter to continue)")
 		print("")
 

--- a/api/client.py
+++ b/api/client.py
@@ -1,9 +1,16 @@
+# from __future__ import absolute_import
+# from __future__ import print_function
+# from builtins import input
+# from builtins import str
+# from builtins import range
 import pprint
 import base64
-import urllib
-import urllib2
+import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
+import six.moves.urllib.request, six.moves.urllib.error, six.moves.urllib.parse
 import json
 import shelve
+from six.moves import range
+from six.moves import input
 __version__ = '1.1'
 '''
 Docket Alarm Python API Client
@@ -42,7 +49,8 @@ def call(call, method="GET", **kwargs):
 
 
 	if PRESS_KEY_BEFORE_CALL:
-		raw_input("(press enter to continue)")
+		# eval(input("(press enter to continue)"))
+		input("(press enter to continue)")
 
 	# Prepare the URL and arguments
 	if USE_LOCAL:
@@ -65,20 +73,20 @@ def call(call, method="GET", **kwargs):
 			kwargs['login_token'] = ''
 
 	# Sort the keywords so they are applied consistently.
-	sorted_kw = sorted(kwargs.items(), key = lambda val: val[0])
-	urlargs = urllib.urlencode(sorted_kw, doseq=True)
+	sorted_kw = sorted(list(kwargs.items()), key = lambda val: val[0])
+	urlargs = six.moves.urllib.parse.urlencode(sorted_kw, doseq=True)
 
 	if method == "GET":
 		url = url + "?" + urlargs
 
 	# Allow for debug printing
 	if DEBUG:
-		print("%s: %s"%(method, url))
+		print(("%s: %s"%(method, url)))
 		if method == "POST":
-			print("ARGUMENTS: %s"%pprint.pformat(urlargs))
+			print(("ARGUMENTS: %s"%pprint.pformat(urlargs)))
 		
 	# Add an authorization header if provided.
-	req = urllib2.Request(url)
+	req = six.moves.urllib.request.Request(url)
 	if username and password:
 		auth = base64.encodestring('%s:%s' % (username, password)).strip()
 		req.add_header("Authorization", "Basic %s" % auth)
@@ -87,9 +95,9 @@ def call(call, method="GET", **kwargs):
 	if _INTERNAL_TESTING:
 		out = _INTERNAL_TESTING(method, url, urlargs)
 	elif method == "GET":
-		out = urllib2.urlopen(req, timeout = TIMEOUT).read()
+		out = six.moves.urllib.request.urlopen(req, timeout = TIMEOUT).read()
 	else:
-		out = urllib2.urlopen(req, urlargs, timeout = TIMEOUT).read()
+		out = six.moves.urllib.request.urlopen(req, six.b(urlargs), timeout = TIMEOUT).read()
 
 	try:
 		out = json.loads(out)
@@ -97,10 +105,11 @@ def call(call, method="GET", **kwargs):
 		raise Exception("Not JSON: " + out)    
 
 	if DEBUG and out and out.get('error'):
-		print "Error: %s"%out['error']
+		print("Error: %s"%out['error'])
 
 	if PRESS_KEY_AFTER_CALL:
-		raw_input("API Call Complete (press enter to continue)")
+		#eval(input("API Call Complete (press enter to continue)"))
+		input("API Call Complete (press enter to continue)")
 		print("")
 
 	return out
@@ -109,7 +118,7 @@ def call(call, method="GET", **kwargs):
 ################################################################################
 #		Utilities and Time Saving Helper Functions
 import time, logging
-from Queue import Empty
+from six.moves.queue import Empty
 from multiprocessing import Process
 from multiprocessing import Pool as MultiProcessPool
 from multiprocessing import Queue as ProcessQueue
@@ -160,7 +169,7 @@ def _dl_worker(username, password, client_matter, cached, dlqueue, docketqueue):
 	
 def getdocket_parallel(username, password, client_matter, docket_list, 
 						cached = False, num_workers = 15,
-						save_progress = None, async = False):
+						save_progress = None, _async = False):
 	'''
 	Download a list of dockets in parallel by launching many processes.
 	
@@ -171,7 +180,7 @@ def getdocket_parallel(username, password, client_matter, docket_list,
 	async               If True, we get data asyncrhonously.
 	'''
 	if save_progress != None:
-		if async:
+		if _async:
 			raise NotImplementedError("Cannot save progress and async.")
 		save_progress = shelve.open(save_progress, 'c')
 	
@@ -242,7 +251,7 @@ def getdocket_parallel(username, password, client_matter, docket_list,
 		pool.close()
 		pool.terminate()
 
-	if async:
+	if _async:
 		return iterator
 
 	for new_i, new_docket in enumerate(iterator()):
@@ -332,7 +341,7 @@ def search_parallel(username, password, client_matter, q,
 	
 	# Put all of the search ranges into the result queue
 	dlqueue = ProcessQueue()
-	for i in xrange(num_first_page, num_results, SEARCH_RESULTS_AT_ONCE):
+	for i in range(num_first_page, num_results, SEARCH_RESULTS_AT_ONCE):
 		limit = min(num_results, i+SEARCH_RESULTS_AT_ONCE) - i
 		logging.info("Added: %s --> %s"%(i, i+limit))
 		dlqueue.put((i, limit))
@@ -357,7 +366,7 @@ def search_parallel(username, password, client_matter, q,
 					start, end, num_results))
 				got += 1
 			except Empty:
-				left = len(results) - len(filter(None, results))
+				left = len(results) - len([_f for _f in results if _f])
 				if left <= 0:
 					break
 				logging.info("Got %d, %d results. Waiting for %d more."%(
@@ -378,7 +387,7 @@ def search_parallel(username, password, client_matter, q,
 	
 	for i, r in enumerate(results):
 		if not r:
-			print "Missing Result %s"%(i+1)
+			print("Missing Result %s"%(i+1))
 		
 	
 	return {

--- a/api/client.py
+++ b/api/client.py
@@ -81,9 +81,9 @@ def call(call, method="GET", **kwargs):
 
 	# Allow for debug printing
 	if DEBUG:
-		print(("%s: %s"%(method, url)))
+		print("%s: %s"%(method, url))
 		if method == "POST":
-			print(("ARGUMENTS: %s"%pprint.pformat(urlargs)))
+			print("ARGUMENTS: %s"%pprint.pformat(urlargs))
 		
 	# Add an authorization header if provided.
 	req = six.moves.urllib.request.Request(url)

--- a/api_test.py
+++ b/api_test.py
@@ -1,3 +1,7 @@
+# from __future__ import absolute_import
+# from __future__ import print_function
+#from builtins import input
+from six.moves import input
 msg="""
 *****************************************************************************
 *                                                                           *
@@ -21,8 +25,8 @@ What you will need:
 import pprint
 import os
 import sys
-import urllib
-import urllib2
+import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
+import six.moves.urllib.request, six.moves.urllib.error, six.moves.urllib.parse
 import logging
 
 # This if statemetn is only really used internally or if you're using it in a 
@@ -94,15 +98,17 @@ part_no = 1
 def print_title(msg):
     global part_no
     print("\n\n---------------------------------")
-    print("Part %d: %s"%(part_no, msg))
+    print(("Part %d: %s"%(part_no, msg)))
     part_no += 1
 
 if __name__ == "__main__":
     print(msg)
     if not username or password:
         print("Enter your Docket Alarm username (your email) and password.")
-        username = raw_input("Username: ")
-        password = raw_input("Password: ")
+        #username = eval(input("Username: "))
+        username = input("Username: ")
+        #password = eval(input("Password: "))
+        password = input("Password: ")
         
     do_getdocket, do_search, do_track_test = True, True, False
     # do_getdocket, do_search, do_track_test = False, False, True

--- a/api_test.py
+++ b/api_test.py
@@ -1,7 +1,3 @@
-# from __future__ import absolute_import
-# from __future__ import print_function
-#from builtins import input
-from six.moves import input
 msg="""
 *****************************************************************************
 *                                                                           *
@@ -21,7 +17,7 @@ What you will need:
   code corresponding to this program.
 
 """
-
+from six.moves import input
 import pprint
 import os
 import sys
@@ -105,9 +101,7 @@ if __name__ == "__main__":
     print(msg)
     if not username or password:
         print("Enter your Docket Alarm username (your email) and password.")
-        #username = eval(input("Username: "))
         username = input("Username: ")
-        #password = eval(input("Password: "))
         password = input("Password: ")
         
     do_getdocket, do_search, do_track_test = True, True, False


### PR DESCRIPTION
@speedplane I used the resources you provided and I have everything working on my end for both Python 3.8.2 and Python 2.7.18. I couldn't get the program to throw any errors while using either of the interpreters. 

I ran two cross-compatibility scripts on the py files. Modernize and Future.

The scripts added an eval() function to the input statements, this made the script crash any time I would input text. Removing eval() allowed me to input text on both versions with no issues.

The other main change that had to be made manually was putting the urlargs variable inside of the six.b() function to specify encoding manually. It would not run on Python 3 without this. I'll include documentation.

Lastly, I changed all mentions of the async variable in client.py to _async. It appears that async is a reserved keyword in Python 3 and It would not run without changing it.

**Docs:**
- https://six.readthedocs.io/
For the six.b() function

- https://python-future.org/compatible_idioms.html
- https://pypi.org/project/future/
Script similar to modernize that I also ran on the py files

- https://intellipaat.com/community/32801/input-error-nameerror-name-is-not-defined
Where I found the solution to the crashes on the input() calls

- https://github.com/swagger-api/swagger-codegen/issues/8328
Where I found out about async keyword causing crashes